### PR TITLE
Parse types in `@return` tag as well.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ will be converted to jsdoc compliant format
 @property {function} b signature `string => string`
 ```
 
-* it supports following tags `@param`,`@type`,`@property`
+* it supports following tags `@param`,`@type`,`@property`,`@return`
 
 ## Notes
 

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ const parseType = (typeString) => {
 const parseTag = (tag) => {
 	let pointer = 0;
 	const tagname = tag.match(/^@\w+/)[0]
-	if (!["@property", "@type", "@param"].includes(tagname)) {
+	if (!["@property", "@type", "@param", "@return"].includes(tagname)) {
 		return tag
 	}
 	tag = tag.replace(/\n/g, " ")


### PR DESCRIPTION
Hi @alshakh, thanks for your plugin! :)

It currently does not support types in `@return` tag.

This PR adds support for it.
